### PR TITLE
Move app navigation to top tabs inside shell card

### DIFF
--- a/app/src/main/java/com/david/qamus/MainActivity.kt
+++ b/app/src/main/java/com/david/qamus/MainActivity.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -114,30 +113,24 @@ fun ArabrusApp() {
 
     val favoriteWords = demoWords.filter { favoriteMarks[it.id] != null && favoriteMarks[it.id] != FavoriteMark.None }
 
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        containerColor = ArabrusBackground,
-        bottomBar = {
-            BottomTabs(
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(ArabrusBackground)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        AppShell {
+            Header()
+            StatusCard()
+            TopTabs(
                 currentScreen = currentScreen,
                 onSelect = { currentScreen = it },
             )
-        },
-    ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .background(ArabrusBackground)
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 12.dp, vertical = 12.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            AppShell {
-                Header()
-                StatusCard()
+            Spacer(Modifier.height(12.dp))
 
-                when (currentScreen) {
+            when (currentScreen) {
                     Screen.Dictionary -> DictionaryScreen(
                         query = query,
                         onQueryChange = { query = it },
@@ -519,18 +512,18 @@ private fun ChipsRow(chips: List<String>) {
 }
 
 @Composable
-private fun BottomTabs(
+private fun TopTabs(
     currentScreen: Screen,
     onSelect: (Screen) -> Unit,
 ) {
-    Surface(
-        color = Color.White,
-        shadowElevation = 8.dp,
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFFE2E8F0), RoundedCornerShape(14.dp))
+            .padding(6.dp),
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 8.dp),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Screen.values().forEach { screen ->
@@ -538,14 +531,14 @@ private fun BottomTabs(
                 Box(
                     modifier = Modifier
                         .weight(1f)
-                        .background(if (selected) ArabrusGreen else Color(0xFFF1F5F9), RoundedCornerShape(12.dp))
+                        .background(if (selected) Color.White else Color.Transparent, RoundedCornerShape(10.dp))
                         .clickable { onSelect(screen) }
-                        .padding(vertical = 10.dp, horizontal = 4.dp),
+                        .padding(vertical = 10.dp, horizontal = 6.dp),
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
                         text = screen.title,
-                        color = if (selected) Color.White else ArabrusMuted,
+                        color = if (selected) ArabrusGreen else ArabrusMuted,
                         fontSize = 11.sp,
                         fontWeight = FontWeight.ExtraBold,
                         textAlign = TextAlign.Center,


### PR DESCRIPTION
### Motivation
- Bring Android UI in line with the web ARABRUS layout by moving navigation into a top tab row inside the white shell card. 
- Remove the bottom navigation as requested and make the tab styling match the product colors. 
- Avoid introducing new icon dependencies so the change is lightweight and build-friendly.

### Description
- Replaced the `Scaffold` + `bottomBar` layout with a centered `Column` and moved navigation into the card via a new `TopTabs` composable. 
- Renamed/rewired the former `BottomTabs` into `TopTabs` and updated the call site inside `AppShell` so tabs render after `StatusCard`. 
- Updated tab visuals to match the requested colors: app background `#F8FAFC` (`ArabrusBackground`), tabs container gray `#E2E8F0`, active tab white with green text `#27AE60`, and white shell (`ArabrusSurface`). 
- Removed the `Scaffold` import and kept a text-only tab implementation (no `Icons.Default` usage), so no extra icon dependencies were added.

### Testing
- Attempted an automated build with `./gradlew :app:assembleDebug`, but the Gradle wrapper download failed in this environment due to a proxy error (`HTTP/1.1 403 Forbidden`), so the build could not complete. 
- No other automated tests were run in this environment; unit/instrumented tests were not executed because the build step did not finish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6419e79e4832ba6f374ca456aab6e)