### PR TITLE
Fix missing Modifier.weight import in MainActivity

### DIFF
--- a/app/src/main/java/com/david/qamus/MainActivity.kt
+++ b/app/src/main/java/com/david/qamus/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape


### PR DESCRIPTION
### Motivation
- Restore Kotlin/Compose compilation by fixing unresolved `Modifier.weight(...)` usages in the UI code.

### Description
- Added `import androidx.compose.foundation.layout.weight` to `app/src/main/java/com/david/qamus/MainActivity.kt`, verified there is no `FlowRow` usage that would require `@OptIn(ExperimentalLayoutApi::class)`, and committed the change (PR #5 updated).

### Testing
- Searched for relevant symbols with `rg -n "WebTab|FlowRow|weight\("`, inspected the change with `git diff`, and attempted `./gradlew :app:compileDebugKotlin` but Gradle distribution download was blocked by proxy (`HTTP 403`), so full compilation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f649a70e20832b9a60f92bb80303b7)