### PR TITLE
Fix WebTab RowScope usage in MainActivity

### DIFF
--- a/app/src/main/java/com/david/qamus/MainActivity.kt
+++ b/app/src/main/java/com/david/qamus/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -526,25 +527,38 @@ private fun TopTabs(
             horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Screen.values().forEach { screen ->
-                val selected = currentScreen == screen
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .background(if (selected) Color.White else Color.Transparent, RoundedCornerShape(10.dp))
-                        .clickable { onSelect(screen) }
-                        .padding(vertical = 10.dp, horizontal = 6.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = screen.title,
-                        color = if (selected) ArabrusGreen else ArabrusMuted,
-                        fontSize = 11.sp,
-                        fontWeight = FontWeight.ExtraBold,
-                        textAlign = TextAlign.Center,
-                    )
-                }
+                WebTab(
+                    title = screen.title,
+                    selected = currentScreen == screen,
+                    onClick = { onSelect(screen) },
+                )
             }
         }
+    }
+}
+
+
+@Composable
+private fun RowScope.WebTab(
+    title: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .weight(1f)
+            .background(if (selected) Color.White else Color.Transparent, RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 10.dp, horizontal = 6.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = title,
+            color = if (selected) ArabrusGreen else ArabrusMuted,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.ExtraBold,
+            textAlign = TextAlign.Center,
+        )
     }
 }
 


### PR DESCRIPTION
### Motivation
- Fix incorrect use of `Modifier.weight(1f)` inside an inline tab `Box` so weighted layout is applied in the correct `Row` scope.
- Ensure the tabs implementation follows Compose `RowScope` conventions and verify whether `FlowRow` requires `@OptIn(ExperimentalLayoutApi::class)`.

### Description
- Replaced the inline `Box` tab implementation in `TopTabs` with a dedicated `WebTab` composable and call `WebTab(...)` for each `Screen`.
- Implemented `WebTab` as `private fun RowScope.WebTab(...)` so `Modifier.weight(1f)` is valid inside the `Row` scope and added the `RowScope` import.
- Checked `MainActivity.kt` for `FlowRow` usage and found none, so no `@OptIn(ExperimentalLayoutApi::class)` was added.

### Testing
- Attempted to run a Kotlin compile with `./gradlew :app:compileDebugKotlin`, which failed due to an environment proxy preventing Gradle distribution download (`HTTP/1.1 403 Forbidden`).
- Verified the file diff for `app/src/main/java/com/david/qamus/MainActivity.kt` to confirm the new `WebTab` signature and `RowScope` import are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64c07bf28832b90f9ccd2f8f52018)